### PR TITLE
Drop dependency on core_intrinsics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oxidize"
 description = "Awesome matchers/asserts"
-version = "0.2.1"
+version = "0.2.2"
 license = "MPL-2.0"
 documentation = "http://github.com/samfoo/oxidize"
 homepage = "http://github.com/samfoo/oxidize"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(core_intrinsics)]
 #![doc(html_root_url="https://samfoo.github.io/oxidize/")]
 #![cfg_attr(test, deny(warnings))]
 

--- a/src/matchers/option.rs
+++ b/src/matchers/option.rs
@@ -1,5 +1,4 @@
 use std::fmt::Debug;
-use std::intrinsics::type_name;
 use super::Matcher;
 
 pub struct Nothing;
@@ -15,7 +14,7 @@ impl<T: Debug> Matcher<Option<T>> for Nothing {
     }
 
     fn negated_fail_msg(&self, lhs: &Option<T>) -> String {
-        format!("expected {:?} to be Some<{}>", lhs, unsafe { type_name::<T>() })
+        format!("expected {:?} to be Some", lhs)
     }
 }
 
@@ -25,7 +24,7 @@ impl<T: Debug> Matcher<Option<T>> for Something {
     }
 
     fn fail_msg(&self, lhs: &Option<T>) -> String {
-        format!("expected {:?} to be Some<{}>", lhs, unsafe { type_name::<T>() })
+        format!("expected {:?} to be Some", lhs)
     }
 
     fn negated_fail_msg(&self, lhs: &Option<T>) -> String {

--- a/src/matchers/option.rs
+++ b/src/matchers/option.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::any::type_name;
 use super::Matcher;
 
 pub struct Nothing;
@@ -14,7 +15,7 @@ impl<T: Debug> Matcher<Option<T>> for Nothing {
     }
 
     fn negated_fail_msg(&self, lhs: &Option<T>) -> String {
-        format!("expected {:?} to be Some", lhs)
+        format!("expected {:?} to be Some<{}>", lhs, type_name::<T>())
     }
 }
 
@@ -24,7 +25,7 @@ impl<T: Debug> Matcher<Option<T>> for Something {
     }
 
     fn fail_msg(&self, lhs: &Option<T>) -> String {
-        format!("expected {:?} to be Some", lhs)
+        format!("expected {:?} to be Some<{}>", lhs, type_name::<T>())
     }
 
     fn negated_fail_msg(&self, lhs: &Option<T>) -> String {


### PR DESCRIPTION
Having it requires rust nightly (core_intrinsics hasn't made it on a stable release). The same functionality is now available through the std library: https://doc.rust-lang.org/std/any/fn.type_name.html

Tests pass locally.